### PR TITLE
Hotfix: Returning correct JSON in server info page

### DIFF
--- a/oppia/templates/oppia/server.html
+++ b/oppia/templates/oppia/server.html
@@ -1,4 +1,4 @@
-{% load i18n %}{'version':'{{ version }}',
-	'name':'{% trans 'app_name' %}',
-	'admin_email':'{% blocktrans with settings.SERVER_EMAIL as email %}{{email}}{% endblocktrans %}',
-	'max_upload':{{ settings.OPPIA_MAX_UPLOAD_SIZE }}}
+{% load i18n %}{"version":"{{ version }}",
+	"name":"{% trans 'app_name' %}",
+	"admin_email":"{% blocktrans with settings.SERVER_EMAIL as email %}{{email}}{% endblocktrans %}",
+	"max_upload":{{ settings.OPPIA_MAX_UPLOAD_SIZE }}}


### PR DESCRIPTION
Needed for the Moodle block to be able to parse the JSON