### PR TITLE
Issue 304

### DIFF
--- a/oppia/local_settings_dev.py
+++ b/oppia/local_settings_dev.py
@@ -10,9 +10,17 @@ def modify(settings):
                                    'crispy_forms',
                                    'tastypie',)
     settings['MIDDLEWARE_CLASSES'] += ('oppia.middleware.LoginRequiredMiddleware',)
-    settings['TEMPLATE_CONTEXT_PROCESSORS'] += ('oppia.context_processors.get_points',)
-    settings['TEMPLATE_CONTEXT_PROCESSORS'] += ('oppia.context_processors.get_version',)
-    settings['TEMPLATE_CONTEXT_PROCESSORS'] += ('oppia.context_processors.get_settings',)
+
+    context_processors = (
+            'oppia.context_processors.get_points',
+            'oppia.context_processors.get_version',
+            'oppia.context_processors.get_settings',)
+
+    if 'TEMPLATES' in settings and settings['TEMPLATES'][0]: #Django 1.8+ template settings
+        settings['TEMPLATES'][0]['OPTIONS']['context_processors'] += context_processors
+    elif 'TEMPLATE_CONTEXT_PROCESSORS' in settings: #Fallback for the old template settings
+        settings['TEMPLATE_CONTEXT_PROCESSORS'] += context_processors
+
     settings['LOGIN_EXEMPT_URLS'] = (
          r'^server/$',
          r'^profile/login/$',

--- a/oppia/local_settings_live.py
+++ b/oppia/local_settings_live.py
@@ -10,9 +10,17 @@ def modify(settings):
                                    'crispy_forms',
                                    'tastypie',)
     settings['MIDDLEWARE_CLASSES'] += ('oppia.middleware.LoginRequiredMiddleware',)
-    settings['TEMPLATE_CONTEXT_PROCESSORS'] += ('oppia.context_processors.get_points',)
-    settings['TEMPLATE_CONTEXT_PROCESSORS'] += ('oppia.context_processors.get_version',)
-    settings['TEMPLATE_CONTEXT_PROCESSORS'] += ('oppia.context_processors.get_settings',)
+
+    context_processors = (
+            'oppia.context_processors.get_points',
+            'oppia.context_processors.get_version',
+            'oppia.context_processors.get_settings',)
+
+    if 'TEMPLATES' in settings and settings['TEMPLATES'][0]: #Django 1.8+ template settings
+        settings['TEMPLATES'][0]['OPTIONS']['context_processors'] += context_processors
+    elif 'TEMPLATE_CONTEXT_PROCESSORS' in settings: #Fallback for the old template settings
+        settings['TEMPLATE_CONTEXT_PROCESSORS'] += context_processors
+
     settings['LOGIN_EXEMPT_URLS'] = (
          r'^server/$',
          r'^profile/login/$',

--- a/oppia/local_settings_staging.py
+++ b/oppia/local_settings_staging.py
@@ -10,9 +10,17 @@ def modify(settings):
                                    'crispy_forms',
                                    'tastypie',)
     settings['MIDDLEWARE_CLASSES'] += ('oppia.middleware.LoginRequiredMiddleware',)
-    settings['TEMPLATE_CONTEXT_PROCESSORS'] += ('oppia.context_processors.get_points',)
-    settings['TEMPLATE_CONTEXT_PROCESSORS'] += ('oppia.context_processors.get_version',)
-    settings['TEMPLATE_CONTEXT_PROCESSORS'] += ('oppia.context_processors.get_settings',)
+
+    context_processors = (
+            'oppia.context_processors.get_points',
+            'oppia.context_processors.get_version',
+            'oppia.context_processors.get_settings',)
+
+    if 'TEMPLATES' in settings and settings['TEMPLATES'][0]: #Django 1.8+ template settings
+        settings['TEMPLATES'][0]['OPTIONS']['context_processors'] += context_processors
+    elif 'TEMPLATE_CONTEXT_PROCESSORS' in settings: #Fallback for the old template settings
+        settings['TEMPLATE_CONTEXT_PROCESSORS'] += context_processors
+
     settings['LOGIN_EXEMPT_URLS'] = (
          r'^server/$',
          r'^profile/login/$',

--- a/oppia/templates/oppia/includes/pagination.html
+++ b/oppia/templates/oppia/includes/pagination.html
@@ -20,7 +20,11 @@
         <li class="active"><a href="{{ ajax_url }}{% query_string "" "page" %}&page={{ page.number }}"> {{ page.number }} <span class="sr-only"> {{ page.number }}</span></a></li>
         {% if page.next_page_number != page.paginator.num_pages %}
             <li><a href="{{ ajax_url }}{% query_string "" "page" %}&page={{ page.next_page_number }}"> {{ page.next_page_number }} <span class="sr-only"> {{ page.next_page_number }}</span></a></li>
-            <li><span>...</span></li>
+            {% with page.next_page_number|add:"1" as secondnext_page %}
+                {% if secondnext_page != page.paginator.num_pages %}
+                    <li><span>...</span></li>
+                {% endif %}
+            {% endwith %}
         {% endif %}
 
       {% if page.has_next %}<li><a href="{{ ajax_url }}{% query_string "" "page" %}&page={{ page.paginator.num_pages }}"> {{ page.paginator.num_pages }} <span class="sr-only"> {{ page.paginator.num_pages }}</span></a></li>{% endif %}


### PR DESCRIPTION
Solves #304: Implemented Django 1.8 template settings approach (with fallback mode)
Now, in the main `settings.py` file, the TEMPLATE_* settings can be replaced with the new TEMPLATE configuration to avoid the deprecation warning:

```
TEMPLATES = [
    {
        'BACKEND': 'django.template.backends.django.DjangoTemplates',
        'DIRS': [],
        'APP_DIRS': True,
        'OPTIONS': {
            'context_processors': [
                'django.template.context_processors.debug',
                'django.template.context_processors.request',
                'django.contrib.auth.context_processors.auth',
                'django.contrib.messages.context_processors.messages',
                'django.core.context_processors.media',
                'django.core.context_processors.static',
                'django.core.context_processors.request',
                'django.core.context_processors.i18n',
            ],
        },
    },
]
```
It tests either way both configuration options, so it won't fail even if the main `settings.py` file remains unchanged.