### PR TITLE
oppia-368: Updated requirements to use a `tablib` compatible version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 django==2.2.10
 django-tastypie==0.14.2
-django-tablib==3.2
 django-crispy-forms==1.7.2
 pytz
 defusedxml==0.5.0
@@ -13,3 +12,4 @@ pycodestyle
 pytest
 pytest-django
 openpyxl==3.0.3
+tablib==2.0.0


### PR DESCRIPTION
Note that not only the version changes but the library, so maybe it is necessary to execute `pip uninstall django-tablib` before updating from requirements