### PR TITLE
OPPIA-1186: Setup ffmpeg in Github actions

### DIFF
--- a/.github/workflows/django_tests.yml
+++ b/.github/workflows/django_tests.yml
@@ -24,6 +24,8 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=79 --statistics
+    - name: Setup FFmpeg
+      uses: FedericoCarboni/setup-ffmpeg@v1
     - name: Test the app with pytest
       run: |
         pip install pytest pytest-django

--- a/tests/api/v1/test_media_upload.py
+++ b/tests/api/v1/test_media_upload.py
@@ -6,6 +6,8 @@ import unittest
 
 from django import forms
 from django.conf import settings
+from django.core.files.uploadedfile import SimpleUploadedFile
+
 from oppia.test import OppiaTestCase
 
 
@@ -85,53 +87,49 @@ class MediaPublishResourceTest(OppiaTestCase):
         user.save()
 
     # check upload works for all users
-    @pytest.mark.xfail(reason="the test framework seems to only recognise the \
-        file as application/octet-stream, so upload ways fails as incorrect \
-        mime-type is found")
-    @unittest.expectedFailure
     def test_upload_user(self):
 
         # normal user
         with open(self.video_file_path, 'rb') as video_file:
+            upload_file = SimpleUploadedFile(video_file.name,
+                                             video_file.read(),
+                                             content_type='video/m4v')
             response = self.client.post(self.url, {'username': 'demo',
                                                    'password': 'password',
-                                                   'media_file': video_file})
+                                                   'media_file': upload_file})
         self.assertEqual(response.status_code, 201)
 
-    @pytest.mark.xfail(reason="the test framework seems to only recognise the \
-        file as application/octet-stream, so upload ways fails as incorrect \
-        mime-type is found")
-    @unittest.expectedFailure
     def test_upload_teacher(self):
         # teacher
         with open(self.video_file_path, 'rb') as video_file:
+            upload_file = SimpleUploadedFile(video_file.name,
+                                             video_file.read(),
+                                             content_type='video/m4v')
             response = self.client.post(self.url, {'username': 'teacher',
                                                    'password': 'password',
-                                                   'media_file': video_file})
+                                                   'media_file': upload_file})
         self.assertEqual(response.status_code, 201)
 
-    @pytest.mark.xfail(reason="the test framework seems to only recognise the \
-        file as application/octet-stream, so upload ways fails as incorrect \
-        mime-type is found")
-    @unittest.expectedFailure
     def test_upload_staff(self):
         # staff
         with open(self.video_file_path, 'rb') as video_file:
+            upload_file = SimpleUploadedFile(video_file.name,
+                                             video_file.read(),
+                                             content_type='video/m4v')
             response = self.client.post(self.url, {'username': 'staff',
                                                    'password': 'password',
-                                                   'media_file': video_file})
+                                                   'media_file': upload_file})
         self.assertEqual(response.status_code, 201)
 
-    @pytest.mark.xfail(reason="the test framework seems to only recognise the \
-        file as application/octet-stream, so upload ways fails as incorrect \
-        mime-type is found")
-    @unittest.expectedFailure
     def test_upload_admin(self):
         # admin
         with open(self.video_file_path, 'rb') as video_file:
+            upload_file = SimpleUploadedFile(video_file.name,
+                                             video_file.read(),
+                                             content_type='video/m4v')
             response = self.client.post(self.url, {'username': 'admin',
                                                    'password': 'password',
-                                                   'media_file': video_file})
+                                                   'media_file': upload_file})
         self.assertEqual(response.status_code, 201)
 
     # test file type

--- a/tests/api/v2/test_media_api.py
+++ b/tests/api/v2/test_media_api.py
@@ -6,6 +6,8 @@ import unittest
 
 from django import forms
 from django.conf import settings
+from django.core.files.uploadedfile import SimpleUploadedFile
+
 from oppia.test import OppiaTestCase
 
 
@@ -88,53 +90,49 @@ class MediaAPIResourceTest(OppiaTestCase):
         user.save()
 
     # check upload works for all users
-    @pytest.mark.xfail(reason="the test framework seems to only recognise the \
-        file as application/octet-stream, so upload ways fails as incorrect \
-        mime-type is found")
-    @unittest.expectedFailure
     def test_upload_user(self):
 
         # normal user
         with open(self.video_file_path, 'rb') as video_file:
+            upload_file = SimpleUploadedFile(video_file.name,
+                                             video_file.read(),
+                                             content_type='video/m4v')
             response = self.client.post(self.url, {'username': 'demo',
                                                    'password': 'password',
-                                                   'media_file': video_file})
+                                                   'media_file': upload_file})
         self.assertEqual(response.status_code, 201)
 
-    @pytest.mark.xfail(reason="the test framework seems to only recognise the \
-        file as application/octet-stream, so upload ways fails as incorrect \
-        mime-type is found")
-    @unittest.expectedFailure
     def test_upload_teacher(self):
         # teacher
         with open(self.video_file_path, 'rb') as video_file:
+            upload_file = SimpleUploadedFile(video_file.name,
+                                             video_file.read(),
+                                             content_type='video/m4v')
             response = self.client.post(self.url, {'username': 'teacher',
                                                    'password': 'password',
-                                                   'media_file': video_file})
+                                                   'media_file': upload_file})
         self.assertEqual(response.status_code, 201)
 
-    @pytest.mark.xfail(reason="the test framework seems to only recognise the \
-        file as application/octet-stream, so upload ways fails as incorrect \
-        mime-type is found")
-    @unittest.expectedFailure
     def test_upload_staff(self):
         # staff
         with open(self.video_file_path, 'rb') as video_file:
+            upload_file = SimpleUploadedFile(video_file.name,
+                                             video_file.read(),
+                                             content_type='video/m4v')
             response = self.client.post(self.url, {'username': 'staff',
                                                    'password': 'password',
-                                                   'media_file': video_file})
+                                                   'media_file': upload_file})
         self.assertEqual(response.status_code, 201)
 
-    @pytest.mark.xfail(reason="the test framework seems to only recognise the \
-        file as application/octet-stream, so upload ways fails as incorrect \
-        mime-type is found")
-    @unittest.expectedFailure
     def test_upload_admin(self):
         # admin
         with open(self.video_file_path, 'rb') as video_file:
+            upload_file = SimpleUploadedFile(video_file.name,
+                                             video_file.read(),
+                                             content_type='video/m4v')
             response = self.client.post(self.url, {'username': 'admin',
                                                    'password': 'password',
-                                                   'media_file': video_file})
+                                                   'media_file': upload_file})
         self.assertEqual(response.status_code, 201)
 
     # test file type


### PR DESCRIPTION
1. Setup fffmpeg in Github actions using [https://github.com/FedericoCarboni/setup-ffmpeg](https://github.com/FedericoCarboni/setup-ffmpeg)
2. Use SimpleUploadedFile for specifying content-type as 'video/m4v'
3. Remove @pytest.mark.xfail and @unittest.expectedFailure tags