### PR TITLE
OPPIA-1167: New status - read only

### DIFF
--- a/gamification/views.py
+++ b/gamification/views.py
@@ -14,7 +14,7 @@ from gamification.models import DefaultGamificationEvent, \
                                 MediaGamificationEvent
 from gamification.xml_writer import GamificationXMLWriter
 from oppia.models import Course, Points, Activity, Media
-from oppia.permissions import can_edit_course
+from oppia.permissions import can_edit_course, can_edit_course_gamification
 
 
 @staff_member_required
@@ -52,7 +52,7 @@ def leaderboard_export(request, course_id=None):
 
 
 def edit_course_gamification(request, course_id):
-    if not can_edit_course(request, course_id):
+    if not can_edit_course_gamification(request, course_id):
         raise PermissionDenied
 
     course = get_object_or_404(Course, pk=course_id)

--- a/oppia/models/main.py
+++ b/oppia/models/main.py
@@ -27,6 +27,7 @@ class CourseStatus(models.TextChoices):
     DRAFT = 'draft', _('Draft')
     ARCHIVED = 'archived', _('Archived')
     NEW_DOWNLOADS_DISABLED = 'new_downloads_disabled', _('New downloads disabled')
+    READ_ONLY = 'read_only', _('Read only')
 
 
 class Course(models.Model):

--- a/oppia/permissions.py
+++ b/oppia/permissions.py
@@ -240,6 +240,12 @@ def can_view_courses_list(request, order_by='title'):
     return courses
 
 
+def can_edit_course_gamification(request, course_id):
+    return can_edit_course(request, course_id) \
+           and Course.objects.filter(CourseFilter.IS_NOT_ARCHIVED & CourseFilter.NEW_DOWNLOADS_ENABLED & CourseFilter.IS_NOT_READ_ONLY)\
+               .filter(pk=course_id).exists()
+
+
 # Sonarcloud raises a code smell that the request and exception params here 
 # are redundant, however, Django requires them
 def oppia_403_handler(request, exception):

--- a/oppia/utils/filters.py
+++ b/oppia/utils/filters.py
@@ -11,6 +11,8 @@ class CourseFilter:
     IS_NOT_DRAFT = ~Q(status=CourseStatus.DRAFT)
     NEW_DOWNLOADS_DISABLED = Q(status=CourseStatus.NEW_DOWNLOADS_DISABLED)
     NEW_DOWNLOADS_ENABLED = ~Q(status=CourseStatus.NEW_DOWNLOADS_DISABLED)
+    IS_READ_ONLY = Q(status=CourseStatus.READ_ONLY)
+    IS_NOT_READ_ONLY = ~Q(status=CourseStatus.READ_ONLY)
 
 
 class CourseCategoryFilter:
@@ -20,3 +22,5 @@ class CourseCategoryFilter:
     COURSE_IS_NOT_DRAFT = ~Q(coursecategory__course__status=CourseStatus.DRAFT)
     COURSE_NEW_DOWNLOADS_DISABLED = Q(coursecategory__course__status=CourseStatus.NEW_DOWNLOADS_DISABLED)
     COURSE_NEW_DOWNLOADS_ENABLED = ~Q(coursecategory__course__status=CourseStatus.NEW_DOWNLOADS_DISABLED)
+    COURSE_IS_READ_ONLY = Q(coursecategory__course__status=CourseStatus.READ_ONLY)
+    COURSE_IS_NOT_READ_ONLY = ~Q(coursecategory__course__status=CourseStatus.READ_ONLY)

--- a/oppia/views/activity.py
+++ b/oppia/views/activity.py
@@ -17,7 +17,7 @@ from oppia.constants import STR_DATE_FORMAT
 from oppia.forms.activity_search import ActivitySearchForm
 from oppia.models import Points, Course
 from oppia.models import Tracker
-from oppia.permissions import can_view_course_detail
+from oppia.permissions import can_view_course_detail, can_edit_course_gamification
 from oppia.views.utils import generate_graph_data
 from profile.views import utils
 from summary.models import CourseDailyStats, UserCourseSummary
@@ -43,6 +43,7 @@ class CourseActivityDetail(DateRangeFilterMixin, DetailView):
         context['download_stats'] = UserCourseSummary.objects.filter(course=self.object.id).aggregated_stats('total_downloads', single=True)
         context['leaderboard'] = Points.get_leaderboard(constants.LEADERBOARD_HOMEPAGE_RESULTS_PER_PAGE, self.object)
         context['data'] = self.get_activity(start_date, end_date, interval)
+        context['can_edit_course_gamification'] = can_edit_course_gamification(self.request, self.object.id)
 
         return context
 

--- a/oppia/views/course.py
+++ b/oppia/views/course.py
@@ -11,7 +11,8 @@ from django.views.generic import TemplateView, ListView, DetailView, FormView
 from helpers.mixins.AjaxTemplateResponseMixin import AjaxTemplateResponseMixin
 from oppia.forms.upload import UploadCourseStep1Form, UploadCourseStep2Form
 from oppia.models import Category, CourseCategory, CoursePublishingLog, Course, CourseStatus
-from oppia.permissions import can_edit_course, can_download_course, can_view_course_detail, can_view_courses_list, can_upload
+from oppia.permissions import can_edit_course, can_download_course, can_view_course_detail, can_view_courses_list, \
+    can_upload, can_edit_course_gamification
 from oppia.signals import course_downloaded
 from oppia.uploader import handle_uploaded_file
 from oppia.utils.filters import CourseFilter
@@ -70,6 +71,7 @@ class CourseListView(ListView, AjaxTemplateResponseMixin):
             except PermissionDenied:
                 course.access_detail = None
             course.can_edit = can_edit_course(self.request, course.id)
+            course.can_edit_gamification = can_edit_course_gamification(self.request, course.id)
             for stats in course_stats:
                 if stats['course'] == course.id:
                     course.distinct_downloads = stats['distinct']

--- a/oppia/views/course.py
+++ b/oppia/views/course.py
@@ -37,7 +37,8 @@ class CourseListView(ListView, AjaxTemplateResponseMixin):
             courses = courses.filter(CourseFilter.IS_NOT_ARCHIVED & CourseFilter.IS_NOT_DRAFT)
         elif course_filter == 'new_downloads_disabled':
             courses = courses.filter(CourseFilter.NEW_DOWNLOADS_DISABLED)
-
+        elif course_filter == 'read_only':
+            courses = courses.filter(CourseFilter.IS_READ_ONLY)
 
         category = self.get_current_category()
         if category is not None:

--- a/templates/course/detail.html
+++ b/templates/course/detail.html
@@ -67,7 +67,9 @@
 		</div>
 		<div class="col-md-6 text-right">
 			<a href="{% url 'oppia:course_edit' course.id %}" class="btn btn-light mr-2 mb-3">{% trans 'Edit' %}</a>
-			<a href="{% url 'oppia_gamification_edit_course' course.id %}" class="btn btn-secondary mb-3">{% trans 'Gamification settings' %}</a>
+			{%  if can_edit_course_gamification %}
+				<a href="{% url 'oppia_gamification_edit_course' course.id %}" class="btn btn-secondary mb-3">{% trans 'Gamification settings' %}</a>
+			{% endif %}
 		</div>
 	</div>
 

--- a/templates/course/list.html
+++ b/templates/course/list.html
@@ -40,6 +40,7 @@
         <option value="draft" {% if course_filter == "draft" %} selected="selected"{% endif %}>{% trans 'Draft' %}</option>
 		<option value="archived" {% if course_filter == "archived" %} selected="selected"{% endif %}>{% trans 'Archived' %}</option>
 		<option value="new_downloads_disabled" {% if course_filter == "new_downloads_disabled" %} selected="selected"{% endif %}>{% trans 'New downloads disabled' %}</option>
+		<option value="read_only" {% if course_filter == "read_only" %} selected="selected"{% endif %}>{% trans 'Read only' %}</option>
 	</select>
 	</form>
 	</div>

--- a/templates/course/query.html
+++ b/templates/course/query.html
@@ -30,7 +30,9 @@
 <td class="py-1">
     {% if item.can_edit %}
         <a href="{% url 'oppia:course_edit' item.id %}" data-toggle="tooltip" title="{% trans 'Edit' %}" class="btn btn-inline btn-outline-primary"><em class="fas fa-2x fa-edit"></em> </a>
-        <a href="{% url 'oppia_gamification_edit_course' item.id %}" data-toggle="tooltip" title="{% trans 'Edit Gamification' %}" class="btn btn-inline btn-outline-primary"><em class="fas fa-2x fa-gamepad"></em></a>
+        {% if item.can_edit_gamification %}
+            <a href="{% url 'oppia_gamification_edit_course' item.id %}" data-toggle="tooltip" title="{% trans 'Edit Gamification' %}" class="btn btn-inline btn-outline-primary"><em class="fas fa-2x fa-gamepad"></em></a>
+        {% endif %}
     {% endif %}
 </td>
 {% endblock %}

--- a/tests/api/v2/test_course.py
+++ b/tests/api/v2/test_course.py
@@ -177,6 +177,30 @@ class CourseResourceTest(ResourceTestCaseMixin, TransactionTestCase):
         self.assertHttpOK(resp)
         self.assertValidJSON(resp.content)
 
+    def test_course_get_single_read_only_normal_visible(self):
+        update_course_status(1, CourseStatus.READ_ONLY)
+        resp = self.perform_request(1, self.user_auth)
+        self.assertHttpOK(resp)
+        self.assertValidJSON(resp.content)
+
+    def test_course_get_single_read_only_staff_visible(self):
+        update_course_status(1, CourseStatus.READ_ONLY)
+        resp = self.perform_request(1, self.staff_auth)
+        self.assertHttpOK(resp)
+        self.assertValidJSON(resp.content)
+
+    def test_course_get_single_read_only_teacher_visible(self):
+        update_course_status(1, CourseStatus.READ_ONLY)
+        resp = self.perform_request(1, self.teacher_auth)
+        self.assertHttpOK(resp)
+        self.assertValidJSON(resp.content)
+
+    def test_course_get_single_read_only_admin_visible(self):
+        update_course_status(1, CourseStatus.READ_ONLY)
+        resp = self.perform_request(1, self.admin_auth)
+        self.assertHttpOK(resp)
+        self.assertValidJSON(resp.content)
+
     def test_course_download_file_zip_not_found(self):
         resp = self.perform_request(5, self.user_auth, self.STR_DOWNLOAD)
         self.assertHttpNotFound(resp)
@@ -226,6 +250,26 @@ class CourseResourceTest(ResourceTestCaseMixin, TransactionTestCase):
 
     def test_download_course_new_downloads_disabled_admin(self):
         update_course_status(1, CourseStatus.NEW_DOWNLOADS_DISABLED)
+        resp = self.perform_request(1, self.admin_auth, self.STR_DOWNLOAD)
+        self.assertHttpOK(resp)
+
+    def test_download_course_read_only_normal(self):
+        update_course_status(1, CourseStatus.READ_ONLY)
+        resp = self.perform_request(1, self.user_auth, self.STR_DOWNLOAD)
+        self.assertHttpOK(resp)
+
+    def test_download_course_read_only_teacher(self):
+        update_course_status(1, CourseStatus.READ_ONLY)
+        resp = self.perform_request(1, self.teacher_auth, self.STR_DOWNLOAD)
+        self.assertHttpOK(resp)
+
+    def test_download_course_read_only_staff(self):
+        update_course_status(1, CourseStatus.READ_ONLY)
+        resp = self.perform_request(1, self.staff_auth, self.STR_DOWNLOAD)
+        self.assertHttpOK(resp)
+
+    def test_download_course_read_only_admin(self):
+        update_course_status(1, CourseStatus.READ_ONLY)
         resp = self.perform_request(1, self.admin_auth, self.STR_DOWNLOAD)
         self.assertHttpOK(resp)
 
@@ -359,6 +403,108 @@ class CourseResourceTest(ResourceTestCaseMixin, TransactionTestCase):
         self.assertEqual(response.status_code, 404)
         tracker_count_end = Tracker.objects.all().count()
         self.assertEqual(tracker_count_start, tracker_count_end)
+
+    def test_new_downloads_disabled_course_admin(self):
+        tracker_count_start = Tracker.objects.all().count()
+        update_course_status(1, CourseStatus.NEW_DOWNLOADS_DISABLED)
+        response = self.perform_request(1, self.admin_auth, self.STR_DOWNLOAD)
+        self.assertHttpOK(response)
+        self.assertEqual(response['content-type'],
+                         self.STR_ZIP_EXPECTED_CONTENT_TYPE)
+        tracker_count_end = Tracker.objects.all().count()
+        self.assertEqual(tracker_count_start+1, tracker_count_end)
+
+    def test_new_downloads_disabled_course_staff(self):
+        tracker_count_start = Tracker.objects.all().count()
+        update_course_status(1, CourseStatus.NEW_DOWNLOADS_DISABLED)
+        response = self.perform_request(1, self.staff_auth, self.STR_DOWNLOAD)
+        self.assertHttpOK(response)
+        self.assertEqual(response['content-type'],
+                         self.STR_ZIP_EXPECTED_CONTENT_TYPE)
+        tracker_count_end = Tracker.objects.all().count()
+        self.assertEqual(tracker_count_start+1, tracker_count_end)
+
+    def test_new_downloads_disabled_course_teacher(self):
+        tracker_count_start = Tracker.objects.all().count()
+        update_course_status(1, CourseStatus.NEW_DOWNLOADS_DISABLED)
+        response = self.perform_request(1, self.teacher_auth, self.STR_DOWNLOAD)
+        self.assertHttpOK(response)
+        self.assertEqual(response['content-type'],
+                         self.STR_ZIP_EXPECTED_CONTENT_TYPE)
+        tracker_count_end = Tracker.objects.all().count()
+        self.assertEqual(tracker_count_start + 1, tracker_count_end)
+
+    def test_new_downloads_disabled_course_teacher_owner(self):
+        tracker_count_start = Tracker.objects.all().count()
+        update_course_status(1, CourseStatus.NEW_DOWNLOADS_DISABLED)
+        update_course_owner(1, self.teacher.id)
+        response = self.perform_request(1, self.teacher_auth, self.STR_DOWNLOAD)
+        self.assertHttpOK(response)
+        self.assertEqual(response['content-type'],
+                         self.STR_ZIP_EXPECTED_CONTENT_TYPE)
+        tracker_count_end = Tracker.objects.all().count()
+        self.assertEqual(tracker_count_start+1, tracker_count_end)
+
+    def test_new_downloads_disabled_course_normal(self):
+        tracker_count_start = Tracker.objects.all().count()
+        update_course_status(1, CourseStatus.NEW_DOWNLOADS_DISABLED)
+        response = self.perform_request(1, self.user_auth, self.STR_DOWNLOAD)
+        self.assertHttpOK(response)
+        self.assertEqual(response['content-type'],
+                         self.STR_ZIP_EXPECTED_CONTENT_TYPE)
+        tracker_count_end = Tracker.objects.all().count()
+        self.assertEqual(tracker_count_start + 1, tracker_count_end)
+
+    def test_read_only_course_admin(self):
+        tracker_count_start = Tracker.objects.all().count()
+        update_course_status(1, CourseStatus.READ_ONLY)
+        response = self.perform_request(1, self.admin_auth, self.STR_DOWNLOAD)
+        self.assertHttpOK(response)
+        self.assertEqual(response['content-type'],
+                         self.STR_ZIP_EXPECTED_CONTENT_TYPE)
+        tracker_count_end = Tracker.objects.all().count()
+        self.assertEqual(tracker_count_start+1, tracker_count_end)
+
+    def test_read_only_course_staff(self):
+        tracker_count_start = Tracker.objects.all().count()
+        update_course_status(1, CourseStatus.READ_ONLY)
+        response = self.perform_request(1, self.staff_auth, self.STR_DOWNLOAD)
+        self.assertHttpOK(response)
+        self.assertEqual(response['content-type'],
+                         self.STR_ZIP_EXPECTED_CONTENT_TYPE)
+        tracker_count_end = Tracker.objects.all().count()
+        self.assertEqual(tracker_count_start+1, tracker_count_end)
+
+    def test_read_only_course_teacher(self):
+        tracker_count_start = Tracker.objects.all().count()
+        update_course_status(1, CourseStatus.READ_ONLY)
+        response = self.perform_request(1, self.teacher_auth, self.STR_DOWNLOAD)
+        self.assertHttpOK(response)
+        self.assertEqual(response['content-type'],
+                         self.STR_ZIP_EXPECTED_CONTENT_TYPE)
+        tracker_count_end = Tracker.objects.all().count()
+        self.assertEqual(tracker_count_start + 1, tracker_count_end)
+
+    def test_read_only_course_teacher_owner(self):
+        tracker_count_start = Tracker.objects.all().count()
+        update_course_status(1, CourseStatus.READ_ONLY)
+        update_course_owner(1, self.teacher.id)
+        response = self.perform_request(1, self.teacher_auth, self.STR_DOWNLOAD)
+        self.assertHttpOK(response)
+        self.assertEqual(response['content-type'],
+                         self.STR_ZIP_EXPECTED_CONTENT_TYPE)
+        tracker_count_end = Tracker.objects.all().count()
+        self.assertEqual(tracker_count_start+1, tracker_count_end)
+
+    def test_read_only_course_normal(self):
+        tracker_count_start = Tracker.objects.all().count()
+        update_course_status(1, CourseStatus.READ_ONLY)
+        response = self.perform_request(1, self.user_auth, self.STR_DOWNLOAD)
+        self.assertHttpOK(response)
+        self.assertEqual(response['content-type'],
+                         self.STR_ZIP_EXPECTED_CONTENT_TYPE)
+        tracker_count_end = Tracker.objects.all().count()
+        self.assertEqual(tracker_count_start + 1, tracker_count_end)
 
     # Course does not exist
     def test_dne_course_admin(self):

--- a/tests/gamification/test_permissions.py
+++ b/tests/gamification/test_permissions.py
@@ -1,6 +1,9 @@
 
 from django.urls import reverse
+
+from oppia.models import CourseStatus
 from oppia.test import OppiaTestCase
+from tests.utils import update_course_status
 
 
 class GamificationPermissionsTest(OppiaTestCase):
@@ -38,12 +41,12 @@ class GamificationPermissionsTest(OppiaTestCase):
         # admin
         self.client.force_login(self.admin_user)
         response = self.client.get(self.invalid_course_url)
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 403)
 
         # staff
         self.client.force_login(self.staff_user)
         response = self.client.get(self.invalid_course_url)
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 403)
 
         # teacher
         self.client.force_login(self.teacher_user)
@@ -53,4 +56,119 @@ class GamificationPermissionsTest(OppiaTestCase):
         # user
         self.client.force_login(self.normal_user)
         response = self.client.get(self.invalid_course_url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_can_edit_gamification_live_course(self):
+        update_course_status(1, CourseStatus.LIVE)
+
+        # admin
+        self.client.force_login(self.admin_user)
+        response = self.client.get(self.valid_course_url)
+        self.assertEqual(response.status_code, 200)
+
+        # staff
+        self.client.force_login(self.staff_user)
+        response = self.client.get(self.valid_course_url)
+        self.assertEqual(response.status_code, 200)
+
+        # teacher
+        self.client.force_login(self.teacher_user)
+        response = self.client.get(self.valid_course_url)
+        self.assertEqual(response.status_code, 403)
+
+        # user
+        self.client.force_login(self.normal_user)
+        response = self.client.get(self.valid_course_url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_can_edit_gamification_draft_course(self):
+        update_course_status(1, CourseStatus.DRAFT)
+
+        # admin
+        self.client.force_login(self.admin_user)
+        response = self.client.get(self.valid_course_url)
+        self.assertEqual(response.status_code, 200)
+
+        # staff
+        self.client.force_login(self.staff_user)
+        response = self.client.get(self.valid_course_url)
+        self.assertEqual(response.status_code, 200)
+
+        # teacher
+        self.client.force_login(self.teacher_user)
+        response = self.client.get(self.valid_course_url)
+        self.assertEqual(response.status_code, 403)
+
+        # user
+        self.client.force_login(self.normal_user)
+        response = self.client.get(self.valid_course_url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_can_edit_gamification_archived_course(self):
+        update_course_status(1, CourseStatus.ARCHIVED)
+
+        # admin
+        self.client.force_login(self.admin_user)
+        response = self.client.get(self.valid_course_url)
+        self.assertEqual(response.status_code, 403)
+
+        # staff
+        self.client.force_login(self.staff_user)
+        response = self.client.get(self.valid_course_url)
+        self.assertEqual(response.status_code, 403)
+
+        # teacher
+        self.client.force_login(self.teacher_user)
+        response = self.client.get(self.valid_course_url)
+        self.assertEqual(response.status_code, 403)
+
+        # user
+        self.client.force_login(self.normal_user)
+        response = self.client.get(self.valid_course_url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_can_edit_gamification_new_downloads_disabled_course(self):
+        update_course_status(1, CourseStatus.NEW_DOWNLOADS_DISABLED)
+
+        # admin
+        self.client.force_login(self.admin_user)
+        response = self.client.get(self.valid_course_url)
+        self.assertEqual(response.status_code, 403)
+
+        # staff
+        self.client.force_login(self.staff_user)
+        response = self.client.get(self.valid_course_url)
+        self.assertEqual(response.status_code, 403)
+
+        # teacher
+        self.client.force_login(self.teacher_user)
+        response = self.client.get(self.valid_course_url)
+        self.assertEqual(response.status_code, 403)
+
+        # user
+        self.client.force_login(self.normal_user)
+        response = self.client.get(self.valid_course_url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_can_edit_gamification_read_only_course(self):
+        update_course_status(1, CourseStatus.READ_ONLY)
+
+        # admin
+        self.client.force_login(self.admin_user)
+        response = self.client.get(self.valid_course_url)
+        self.assertEqual(response.status_code, 403)
+
+        # staff
+        self.client.force_login(self.staff_user)
+        response = self.client.get(self.valid_course_url)
+        self.assertEqual(response.status_code, 403)
+
+        # teacher
+        self.client.force_login(self.teacher_user)
+        response = self.client.get(self.valid_course_url)
+        self.assertEqual(response.status_code, 403)
+
+        # user
+        self.client.force_login(self.normal_user)
+        response = self.client.get(self.valid_course_url)
         self.assertEqual(response.status_code, 403)

--- a/tests/oppia/views/test_app_launch_activity.py
+++ b/tests/oppia/views/test_app_launch_activity.py
@@ -61,7 +61,7 @@ class AppLaunchActivityTest(OppiaTestCase):
     def test_no_access_for_draft_course(self):
         url = ('%s?course=' + self.valid_course) \
             % reverse(self.STR_URL_REDIRECT)
-        update_course_status(1, CourseStatus.ARCHIVED)
+        update_course_status(1, CourseStatus.DRAFT)
         response = self.client.get(url)
         self.assertRaises(Http404)
         self.assertTemplateUsed(response, self.STR_LAUNCHER_TEMPLATE)

--- a/tests/oppia/views/test_course_download.py
+++ b/tests/oppia/views/test_course_download.py
@@ -125,6 +125,74 @@ class DownloadViewTest(OppiaTestCase):
         self.assertEqual(response.status_code, 404)
         update_course_status(1, CourseStatus.LIVE)
 
+    def test_new_downloads_disabled_course_admin(self):
+        update_course_status(1, CourseStatus.NEW_DOWNLOADS_DISABLED)
+        response = self.get_view(self.course_download_url_valid,
+                                 self.admin_user)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['content-type'],
+                         self.STR_EXPECTED_CONTENT_TYPE)
+        update_course_status(1, CourseStatus.LIVE)
+
+    def test_new_downloads_disabled_course_staff(self):
+        update_course_status(1, CourseStatus.NEW_DOWNLOADS_DISABLED)
+        response = self.get_view(self.course_download_url_valid,
+                                 self.staff_user)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['content-type'],
+                         self.STR_EXPECTED_CONTENT_TYPE)
+        update_course_status(1, CourseStatus.LIVE)
+
+    def test_new_downloads_disabled_course_teacher(self):
+        update_course_status(1, CourseStatus.NEW_DOWNLOADS_DISABLED)
+        response = self.get_view(self.course_download_url_valid,
+                                 self.teacher_user)
+        self.assertEqual(response.status_code, 404)
+        update_course_status(1, CourseStatus.LIVE)
+
+    def test_new_downloads_disabled_course_normal(self):
+        update_course_status(1, CourseStatus.NEW_DOWNLOADS_DISABLED)
+        response = self.get_view(self.course_download_url_valid,
+                                 self.normal_user)
+        self.assertEqual(response.status_code, 404)
+        update_course_status(1, CourseStatus.LIVE)
+
+    def test_read_only_course_admin(self):
+        update_course_status(1, CourseStatus.READ_ONLY)
+        response = self.get_view(self.course_download_url_valid,
+                                 self.admin_user)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['content-type'],
+                         self.STR_EXPECTED_CONTENT_TYPE)
+        update_course_status(1, CourseStatus.LIVE)
+
+    def test_read_only_course_staff(self):
+        update_course_status(1, CourseStatus.READ_ONLY)
+        response = self.get_view(self.course_download_url_valid,
+                                 self.staff_user)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['content-type'],
+                         self.STR_EXPECTED_CONTENT_TYPE)
+        update_course_status(1, CourseStatus.LIVE)
+
+    def test_read_only_course_teacher(self):
+        update_course_status(1, CourseStatus.READ_ONLY)
+        response = self.get_view(self.course_download_url_valid,
+                                 self.teacher_user)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['content-type'],
+                         self.STR_EXPECTED_CONTENT_TYPE)
+        update_course_status(1, CourseStatus.LIVE)
+
+    def test_read_only_course_normal(self):
+        update_course_status(1, CourseStatus.READ_ONLY)
+        response = self.get_view(self.course_download_url_valid,
+                                 self.normal_user)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['content-type'],
+                         self.STR_EXPECTED_CONTENT_TYPE)
+        update_course_status(1, CourseStatus.LIVE)
+
     # Course does not exist
     def test_dne_course_admin(self):
         response = self.get_view(self.course_download_url_invalid,


### PR DESCRIPTION
1. [OPPIA-1177: Add new course status - read only](https://github.com/DigitalCampus/django-oppia/commit/b3d22e164365dfd1836038dbcac3a69ab120b5f4)
2. [OPPIA-1178: Prevent editing of gamification](https://github.com/DigitalCampus/django-oppia/commit/20dbbc48804d494f7bb492ea82512ad4a32f9e56)



3. [OPPIA-1179: Add tests for read-only status](https://github.com/DigitalCampus/django-oppia/commit/404f86a42969447e37f1a7cd8a5ba4f12ff6d7a1)