### PR TITLE
OPPIA-1165: Simplify how course status is represented

### DIFF
--- a/oppia/models/main.py
+++ b/oppia/models/main.py
@@ -230,6 +230,18 @@ class Course(models.Model):
 
         return tracker_viewed
 
+    def is_live(self):
+        return self.status == CourseStatus.LIVE
+
+    def is_draft(self):
+        return self.status == CourseStatus.DRAFT
+
+    def is_archived(self):
+        return self.status == CourseStatus.ARCHIVED
+
+    def are_new_downloads_disabled(self):
+        return self.status == CourseStatus.NEW_DOWNLOADS_DISABLED
+
 
 class CoursePermissions(models.Model):
 

--- a/oppia/views/course.py
+++ b/oppia/views/course.py
@@ -147,8 +147,7 @@ class CourseFormView(CanEditCoursePermission, FormView):
 
     def get_initial(self):
         return {'categories': self.course.get_categories(),
-                'is_draft': CourseStatus.DRAFT in self.course.status,
-                'new_downloads_enabled': CourseStatus.NEW_DOWNLOADS_DISABLED not in self.course.status}
+                'status': self.course.status}
 
     def form_valid(self, form):
         self.update_course_tags(form, self.course, self.request.user)

--- a/templates/common/info_badge.html
+++ b/templates/common/info_badge.html
@@ -1,6 +1,6 @@
 
 {% load i18n %}
 
-{% if course.status != 'live' %}
+{% if not course.is_live %}
     <span class="badge badge-dark ml-2"><small>{% trans course.get_status_display %}</small></span>
 {% endif %}

--- a/templates/course/detail_card.html
+++ b/templates/course/detail_card.html
@@ -14,11 +14,14 @@
             {{ course.description|title_lang:LANGUAGE_CODE|default_if_none:"No description"  }}
         </p>
         {% if extended %}
-        <strong class="text-black-50">{% trans 'Shortname:' %}</strong> <code>{{ course.shortname }}</code><br>
-        <strong class="text-black-50">{% trans 'Version:' %}</strong> <code>{{ course.version }}</code><br>
-        <strong class="text-black-50">{% trans 'Created:' %} </strong> {{ course.created_date }}<br>
-        <strong class="text-black-50">{% trans 'Last updated:' %} </strong> {{ course.lastupdated_date }}<br>
-        <a href="{% url 'oppia:course_download' course.id %}" class="btn btn-primary mt-3 mb-2"><em class="fas mr-2 fa-arrow-down"></em> {% trans 'Download course' %}</a><br>
+            <strong class="text-black-50">{% trans 'Shortname:' %}</strong> <code>{{ course.shortname }}</code><br>
+            <strong class="text-black-50">{% trans 'Version:' %}</strong> <code>{{ course.version }}</code><br>
+            <strong class="text-black-50">{% trans 'Created:' %} </strong> {{ course.created_date }}<br>
+            <strong class="text-black-50">{% trans 'Last updated:' %} </strong> {{ course.lastupdated_date }}<br>
+        
+            {% if not course.is_archived %}
+                 <a href="{% url 'oppia:course_download' course.id %}" class="btn btn-primary mt-3 mb-2"><em class="fas mr-2 fa-arrow-down"></em> {% trans 'Download course' %}</a><br>
+            {% endif %}
         {% endif %}
 
         {{ download_stats.total|default:0 }} downloads by {{ download_stats.distinct|default:0 }} users


### PR DESCRIPTION
1. Set current status when editing course. 
2. Hide 'download course' button if course is archived. 
3. Add helper methods for checking the course status.