### PR TITLE
OPPIA-1250: Filter categories depending on course status and user type

### DIFF
--- a/tests/api/v2/test_category.py
+++ b/tests/api/v2/test_category.py
@@ -1,9 +1,10 @@
+import json
 
 from django.contrib.auth.models import User
 from django.test import TestCase
 from tastypie.test import ResourceTestCaseMixin
 
-from oppia.models import CourseStatus
+from oppia.models import CourseStatus, CoursePermissions, Course
 from tests.utils import get_api_key, get_api_url, update_course_status
 
 
@@ -13,12 +14,27 @@ class CategoryResourceTest(ResourceTestCaseMixin, TestCase):
 
     def setUp(self):
         super(CategoryResourceTest, self).setUp()
-        user = User.objects.get(username='demo')
-        api_key = get_api_key(user=user)
-        self.auth_data = {
+        self.user = User.objects.get(username='demo')
+        self.admin = User.objects.get(username='admin')
+        self.staff = User.objects.get(username='staff')
+        self.teacher = User.objects.get(username='teacher')
+        self.user_auth = {
             'username': 'demo',
-            'api_key': api_key.key,
+            'api_key': get_api_key(user=self.user).key,
         }
+        self.admin_auth = {
+            'username': 'admin',
+            'api_key': get_api_key(user=self.admin).key
+        }
+        self.staff_auth = {
+            'username': 'staff',
+            'api_key': get_api_key(user=self.staff).key
+        }
+        self.teacher_auth = {
+            'username': 'teacher',
+            'api_key': get_api_key(user=self.teacher).key
+        }
+
         self.url = get_api_url('v2', 'tag')
 
     # Post invalid
@@ -38,13 +54,13 @@ class CategoryResourceTest(ResourceTestCaseMixin, TestCase):
     # test authorized
     def test_authorized(self):
         resp = self.api_client.get(
-            self.url, format='json', data=self.auth_data)
+            self.url, format='json', data=self.user_auth)
         self.assertHttpOK(resp)
 
     # test valid json response and with 5 tags
     def test_has_categories(self):
         resp = self.api_client.get(
-            self.url, format='json', data=self.auth_data)
+            self.url, format='json', data=self.user_auth)
         self.assertHttpOK(resp)
         self.assertValidJSON(resp.content)
         response_data = self.deserialize(resp)
@@ -66,7 +82,7 @@ class CategoryResourceTest(ResourceTestCaseMixin, TestCase):
         resource_url = get_api_url('v2', 'tag', 2)
         resp = self.api_client.get(resource_url,
                                    format='json',
-                                   data=self.auth_data)
+                                   data=self.user_auth)
         self.assertHttpOK(resp)
         self.assertValidJSON(resp.content)
         response_data = self.deserialize(resp)
@@ -86,18 +102,18 @@ class CategoryResourceTest(ResourceTestCaseMixin, TestCase):
         resource_url = get_api_url('v2', 'tag', 999)
         resp = self.api_client.get(resource_url,
                                    format='json',
-                                   data=self.auth_data)
+                                   data=self.user_auth)
         self.assertHttpNotFound(resp)
 
     def test_count_new_downloads_enabled(self):
         # Expected count of courses having new downloads enabled by category (based on test_oppia.json)
-        expected = {'HEAT': 2, 'ANC': 1, 'Antenatal Care': 1, 'NCD': 1, 'reference': 1}
+        expected = {'HEAT': 2, 'ANC': 1, 'Antenatal Care': 1, 'NCD': 1, 'reference': 0}
 
         # Disable new downloads from 1 of the 4 courses (ref-1)
         update_course_status(4, CourseStatus.NEW_DOWNLOADS_DISABLED)
 
         resp = self.api_client.get(
-            self.url, format='json', data=self.auth_data)
+            self.url, format='json', data=self.user_auth)
         self.assertHttpOK(resp)
         self.assertValidJSON(resp.content)
         response_data = self.deserialize(resp)
@@ -113,7 +129,7 @@ class CategoryResourceTest(ResourceTestCaseMixin, TestCase):
             'ANC': {'anc1-all': 'live'},
             'Antenatal Care': {'anc1-all': 'live'},
             'NCD': {'ncd1-et': 'new_downloads_disabled'},
-            'reference': {'ref-1': 'new_downloads_disabled', 'draft-test': 'draft'}
+            'reference': {'ref-1': 'new_downloads_disabled'}
             }
 
         # Disable new downloads from 2 of the 4 courses (ncd1-et and ref-1)
@@ -121,7 +137,7 @@ class CategoryResourceTest(ResourceTestCaseMixin, TestCase):
         update_course_status(4, CourseStatus.NEW_DOWNLOADS_DISABLED)
 
         resp = self.api_client.get(
-            self.url, format='json', data=self.auth_data)
+            self.url, format='json', data=self.user_auth)
         self.assertHttpOK(resp)
         self.assertValidJSON(resp.content)
         response_data = self.deserialize(resp)
@@ -129,3 +145,323 @@ class CategoryResourceTest(ResourceTestCaseMixin, TestCase):
         for tag in response_data['tags']:
             self.assertTrue('course_statuses' in tag)
             self.assertEqual(expected.get(tag['name']), tag['course_statuses'])
+
+    def test_draft_course_is_not_included_in_course_statuses_normal_user(self):
+        expected1 = {
+            'reference': {'ref-1': 'live'}
+        }
+
+        resp = self.api_client.get(
+            self.url, format='json', data=self.user_auth)
+        self.assertHttpOK(resp)
+        self.assertValidJSON(resp.content)
+        response_data = self.deserialize(resp)
+        self.assertTrue('tags' in response_data)
+        tags = response_data['tags']
+        course_statuses = next((tag['course_statuses'] for tag in tags if tag['name'] == 'reference'))
+        self.assertEqual(expected1.get('reference'), course_statuses)
+
+    def test_draft_course_is_not_included_in_course_statuses_teacher_user(self):
+        expected = {
+            'reference': {'ref-1': 'live'}
+        }
+
+        resp = self.api_client.get(
+            self.url, format='json', data=self.teacher_auth)
+        self.assertHttpOK(resp)
+        self.assertValidJSON(resp.content)
+        response_data = self.deserialize(resp)
+        self.assertTrue('tags' in response_data)
+        tags = response_data['tags']
+        course_statuses = next((tag['course_statuses'] for tag in tags if tag['name'] == 'reference'))
+        self.assertEqual(expected.get('reference'), course_statuses)
+
+    def test_draft_course_is_included_in_course_statuses_staff_user(self):
+        expected = {
+            'reference': {'ref-1': 'live', 'draft-test': 'draft'}
+        }
+
+        resp = self.api_client.get(
+            self.url, format='json', data=self.staff_auth)
+        self.assertHttpOK(resp)
+        self.assertValidJSON(resp.content)
+        response_data = self.deserialize(resp)
+        self.assertTrue('tags' in response_data)
+        tags = response_data['tags']
+        course_statuses = next((tag['course_statuses'] for tag in tags if tag['name'] == 'reference'))
+        self.assertEqual(expected.get('reference'), course_statuses)
+
+    def test_draft_course_is_included_in_course_statuses_admin_user(self):
+        expected = {
+            'reference': {'ref-1': 'live', 'draft-test': 'draft'}
+        }
+
+        resp = self.api_client.get(
+            self.url, format='json', data=self.admin_auth)
+        self.assertHttpOK(resp)
+        self.assertValidJSON(resp.content)
+        response_data = self.deserialize(resp)
+        self.assertTrue('tags' in response_data)
+        tags = response_data['tags']
+        course_statuses = next((tag['course_statuses'] for tag in tags if tag['name'] == 'reference'))
+        self.assertEqual(expected.get('reference'), course_statuses)
+
+    def test_draft_course_is_included_in_course_statuses_normal_user_with_viewer_permissions(self):
+        expected = {
+            'reference': {'ref-1': 'live', 'draft-test': 'draft'}
+        }
+
+        # Add Viewer permission to normal user
+        CoursePermissions.objects.create(
+            course=Course.objects.get(shortname='draft-test'),
+            user=self.user,
+            role=CoursePermissions.VIEWER
+        )
+
+        resp = self.api_client.get(
+            self.url, format='json', data=self.admin_auth)
+        self.assertHttpOK(resp)
+        self.assertValidJSON(resp.content)
+        response_data = self.deserialize(resp)
+        self.assertTrue('tags' in response_data)
+        tags = response_data['tags']
+        course_statuses = next((tag['course_statuses'] for tag in tags if tag['name'] == 'reference'))
+        self.assertEqual(expected.get('reference'), course_statuses)
+
+    def test_draft_course_is_included_in_course_statuses_normal_user_with_manager_permissions(self):
+        expected = {
+            'reference': {'ref-1': 'live', 'draft-test': 'draft'}
+        }
+
+        # Add Viewer permission to normal user
+        CoursePermissions.objects.create(
+            course=Course.objects.get(shortname='draft-test'),
+            user=self.user,
+            role=CoursePermissions.MANAGER
+        )
+
+        resp = self.api_client.get(
+            self.url, format='json', data=self.admin_auth)
+        self.assertHttpOK(resp)
+        self.assertValidJSON(resp.content)
+        response_data = self.deserialize(resp)
+        self.assertTrue('tags' in response_data)
+        tags = response_data['tags']
+        course_statuses = next((tag['course_statuses'] for tag in tags if tag['name'] == 'reference'))
+        self.assertEqual(expected.get('reference'), course_statuses)
+
+    def test_draft_course_is_included_in_course_statuses_normal_teacher_with_viewer_permissions(self):
+        expected = {
+            'reference': {'ref-1': 'live', 'draft-test': 'draft'}
+        }
+
+        # Add Viewer permission to normal user
+        CoursePermissions.objects.create(
+            course=Course.objects.get(shortname='draft-test'),
+            user=self.teacher,
+            role=CoursePermissions.VIEWER
+        )
+
+        resp = self.api_client.get(
+            self.url, format='json', data=self.admin_auth)
+        self.assertHttpOK(resp)
+        self.assertValidJSON(resp.content)
+        response_data = self.deserialize(resp)
+        self.assertTrue('tags' in response_data)
+        tags = response_data['tags']
+        course_statuses = next((tag['course_statuses'] for tag in tags if tag['name'] == 'reference'))
+        self.assertEqual(expected.get('reference'), course_statuses)
+
+    def test_draft_course_is_included_in_course_statuses_normal_teacher_with_manager_permissions(self):
+        expected = {
+            'reference': {'ref-1': 'live', 'draft-test': 'draft'}
+        }
+
+        # Add Viewer permission to normal user
+        CoursePermissions.objects.create(
+            course=Course.objects.get(shortname='draft-test'),
+            user=self.teacher,
+            role=CoursePermissions.MANAGER
+        )
+
+        resp = self.api_client.get(
+            self.url, format='json', data=self.admin_auth)
+        self.assertHttpOK(resp)
+        self.assertValidJSON(resp.content)
+        response_data = self.deserialize(resp)
+        self.assertTrue('tags' in response_data)
+        tags = response_data['tags']
+        course_statuses = next((tag['course_statuses'] for tag in tags if tag['name'] == 'reference'))
+        self.assertEqual(expected.get('reference'), course_statuses)
+
+    def test_archived_course_is_not_included_in_course_statuses_normal_user(self):
+        expected1 = {
+            'reference': {'ref-1': 'live'}
+        }
+
+        # Set draft-test course to archived status
+        update_course_status(3, CourseStatus.ARCHIVED)
+
+        resp = self.api_client.get(
+            self.url, format='json', data=self.user_auth)
+        self.assertHttpOK(resp)
+        self.assertValidJSON(resp.content)
+        response_data = self.deserialize(resp)
+        self.assertTrue('tags' in response_data)
+        tags = response_data['tags']
+        course_statuses = next((tag['course_statuses'] for tag in tags if tag['name'] == 'reference'))
+        self.assertEqual(expected1.get('reference'), course_statuses)
+
+    def test_archived_course_is_not_included_in_course_statuses_teacher_user(self):
+        expected = {
+            'reference': {'ref-1': 'live'}
+        }
+
+        # Set draft-test course to archived status
+        update_course_status(3, CourseStatus.ARCHIVED)
+
+        resp = self.api_client.get(
+            self.url, format='json', data=self.teacher_auth)
+        self.assertHttpOK(resp)
+        self.assertValidJSON(resp.content)
+        response_data = self.deserialize(resp)
+        self.assertTrue('tags' in response_data)
+        tags = response_data['tags']
+        course_statuses = next((tag['course_statuses'] for tag in tags if tag['name'] == 'reference'))
+        self.assertEqual(expected.get('reference'), course_statuses)
+
+    def test_archived_course_is_not_included_in_course_statuses_staff_user(self):
+        expected = {
+            'reference': {'ref-1': 'live'}
+        }
+
+        # Set draft-test course to archived status
+        update_course_status(3, CourseStatus.ARCHIVED)
+
+        resp = self.api_client.get(
+            self.url, format='json', data=self.staff_auth)
+        self.assertHttpOK(resp)
+        self.assertValidJSON(resp.content)
+        response_data = self.deserialize(resp)
+        self.assertTrue('tags' in response_data)
+        tags = response_data['tags']
+        course_statuses = next((tag['course_statuses'] for tag in tags if tag['name'] == 'reference'))
+        self.assertEqual(expected.get('reference'), course_statuses)
+
+    def test_archived_course_is_not_included_in_course_statuses_admin_user(self):
+        expected = {
+            'reference': {'ref-1': 'live'}
+        }
+
+        # Set draft-test course to archived status
+        update_course_status(3, CourseStatus.ARCHIVED)
+
+        resp = self.api_client.get(
+            self.url, format='json', data=self.admin_auth)
+        self.assertHttpOK(resp)
+        self.assertValidJSON(resp.content)
+        response_data = self.deserialize(resp)
+        self.assertTrue('tags' in response_data)
+        tags = response_data['tags']
+        course_statuses = next((tag['course_statuses'] for tag in tags if tag['name'] == 'reference'))
+        self.assertEqual(expected.get('reference'), course_statuses)
+
+    def test_archived_course_is_not_included_in_course_statuses_normal_user_with_viewer_permissions(self):
+        expected = {
+            'reference': {'ref-1': 'live'}
+        }
+
+        # Set draft-test course to archived status
+        update_course_status(3, CourseStatus.ARCHIVED)
+
+        # Add Viewer permission to normal user
+        CoursePermissions.objects.create(
+            course=Course.objects.get(shortname='draft-test'),
+            user=self.user,
+            role=CoursePermissions.VIEWER
+        )
+
+        resp = self.api_client.get(
+            self.url, format='json', data=self.admin_auth)
+        self.assertHttpOK(resp)
+        self.assertValidJSON(resp.content)
+        response_data = self.deserialize(resp)
+        self.assertTrue('tags' in response_data)
+        tags = response_data['tags']
+        course_statuses = next((tag['course_statuses'] for tag in tags if tag['name'] == 'reference'))
+        self.assertEqual(expected.get('reference'), course_statuses)
+
+    def test_archived_course_is_not_included_in_course_statuses_normal_user_with_manager_permissions(self):
+        expected = {
+            'reference': {'ref-1': 'live'}
+        }
+
+        # Set draft-test course to archived status
+        update_course_status(3, CourseStatus.ARCHIVED)
+
+        # Add Viewer permission to normal user
+        CoursePermissions.objects.create(
+            course=Course.objects.get(shortname='draft-test'),
+            user=self.user,
+            role=CoursePermissions.MANAGER
+        )
+
+        resp = self.api_client.get(
+            self.url, format='json', data=self.admin_auth)
+        self.assertHttpOK(resp)
+        self.assertValidJSON(resp.content)
+        response_data = self.deserialize(resp)
+        self.assertTrue('tags' in response_data)
+        tags = response_data['tags']
+        course_statuses = next((tag['course_statuses'] for tag in tags if tag['name'] == 'reference'))
+        self.assertEqual(expected.get('reference'), course_statuses)
+
+    def test_archived_course_is_not_included_in_course_statuses_normal_teacher_with_viewer_permissions(self):
+        expected = {
+            'reference': {'ref-1': 'live'}
+        }
+
+        # Set draft-test course to archived status
+        update_course_status(3, CourseStatus.ARCHIVED)
+
+        # Add Viewer permission to normal user
+        CoursePermissions.objects.create(
+            course=Course.objects.get(shortname='draft-test'),
+            user=self.teacher,
+            role=CoursePermissions.VIEWER
+        )
+
+        resp = self.api_client.get(
+            self.url, format='json', data=self.admin_auth)
+        self.assertHttpOK(resp)
+        self.assertValidJSON(resp.content)
+        response_data = self.deserialize(resp)
+        self.assertTrue('tags' in response_data)
+        tags = response_data['tags']
+        course_statuses = next((tag['course_statuses'] for tag in tags if tag['name'] == 'reference'))
+        self.assertEqual(expected.get('reference'), course_statuses)
+
+    def test_archived_course_is_not_included_in_course_statuses_normal_teacher_with_manager_permissions(self):
+        expected = {
+            'reference': {'ref-1': 'live'}
+        }
+
+        # Set draft-test course to archived status
+        update_course_status(3, CourseStatus.ARCHIVED)
+
+        # Add Viewer permission to normal user
+        CoursePermissions.objects.create(
+            course=Course.objects.get(shortname='draft-test'),
+            user=self.teacher,
+            role=CoursePermissions.MANAGER
+        )
+
+        resp = self.api_client.get(
+            self.url, format='json', data=self.admin_auth)
+        self.assertHttpOK(resp)
+        self.assertValidJSON(resp.content)
+        response_data = self.deserialize(resp)
+        self.assertTrue('tags' in response_data)
+        tags = response_data['tags']
+        course_statuses = next((tag['course_statuses'] for tag in tags if tag['name'] == 'reference'))
+        self.assertEqual(expected.get('reference'), course_statuses)


### PR DESCRIPTION
Don't include course categories if:
- The coure is in 'archived' status
- The user is a 'regular' user, the course is in 'draft' status and the user doesn't have permissions for that course