### PR TITLE
OPPIA-1651 Add docker integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM ghcr.io/astral-sh/uv:0.2.12 as uv
+FROM python:3.8.19-slim-bullseye
+
+RUN --mount=from=uv,source=/uv,target=./uv \
+    ./uv venv /opt/venv
+ENV VIRTUAL_ENV=/opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+WORKDIR /code
+
+COPY . .
+
+RUN apt-get update -y && \
+    apt-get install -y python3-dev default-libmysqlclient-dev build-essential pkg-config && \
+    pip install --upgrade pip
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=from=uv,source=/uv,target=./uv \
+    ./uv pip install  -r requirements.txt
+
+RUN chmod +x /code/entrypoint.sh
+
+ENTRYPOINT ["sh", "/code/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,42 @@
+
+services:
+  web:
+    build: .
+    command: python manage.py runserver 0.0.0.0:8000
+    ports:
+      - "${DJANGO_PORT:-8000}:8000"
+    volumes:
+      - .:/code
+      - ../static:/static
+      - ../media:/media
+      - ../upload:/upload
+    depends_on:
+      db:
+        condition: service_healthy
+  db:
+    image: mysql:8.0
+    ports:
+      - "${DB_PORT:-3306}:${DB_PORT:-3306}"
+    volumes:
+      - data:/var/lib/mysql
+    environment:
+      MYSQL_ROOT_PASSWORD_FILE: /run/secrets/db_root_password
+      MYSQL_DATABASE: oppia
+      MYSQL_USER: oppiauser
+      MYSQL_PASSWORD_FILE: /run/secrets/db_password
+    secrets:
+      - db_root_password
+      - db_password
+    healthcheck:
+      test: [ "CMD", "mysqladmin", "ping", "-h", "localhost" ]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+
+secrets:
+  db_password:
+    file: ./db_password.txt
+  db_root_password:
+    file: ./db_root_password.txt
+volumes:
+  data:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+echo 'Running migrations...'
+python manage.py migrate
+
+echo 'Collecting static files...'
+python manage.py collectstatic --no-input
+
+echo 'Starting Django Server...'
+exec "$@"


### PR DESCRIPTION
Instructions to tests:

1. Install Docker on your machine: https://docs.docker.com/engine/install/
2. Install Docker Compose (or Docker  Desktop which includes Compose): https://docs.docker.com/compose/install/
3. Create two files in the root dir:
    - db_password.txt: The content of this file should be the desired password for the oppia db user
    - db_root_password.txt: The content of this file should be the desired password for the root db user

4. From the directory where the docker-compose.yml file is, run `docker compose up`
5. Wait until the log prints `Starting Django Server...` and check that the server starts at `localhost:8000`
6. Once everything works, you can remove the local files created in step 3 as they are only needed during docker build