### PR TITLE
Fix off-by-one error in data retention command

### DIFF
--- a/oppia/management/commands/data_retention.py
+++ b/oppia/management/commands/data_retention.py
@@ -55,7 +55,7 @@ class Command(BaseCommand):
         last_login_date = timezone.now() - relativedelta(years=years)
 
         users_to_delete = []
-        users = User.objects.filter(last_login__lte=last_login_date)
+        users = User.objects.filter(last_login__lt=last_login_date)
 
         for user in users:
             no_trackers = Tracker.objects.filter(


### PR DESCRIPTION
## Problem

The data retention command was using `last_login__lte=last_login_date` which included users who logged in exactly X years ago. This meant a user who logged in exactly 3 years ago (when retention is set to 3 years) would be deleted, when they should be retained for the full 3-year period.

## Solution

Changed the filter from `last_login__lte` (less than or equal to) to `last_login__lt` (less than). This ensures:
- Users who logged in **more than** X years ago are deleted
- Users who logged in **exactly** X years ago or more recently are retained

## Example

With a 3-year retention period:
- User logged in 3 years and 1 day ago → deleted ✓
- User logged in exactly 3 years ago → **retained** (fixed)
- User logged in 2 years ago → retained ✓

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.